### PR TITLE
Prevent Pickpocket When at or Below HP Threshold Toggle

### DIFF
--- a/src/main/java/com/pickpockethelper/AlertManager.java
+++ b/src/main/java/com/pickpockethelper/AlertManager.java
@@ -38,7 +38,7 @@ public class AlertManager {
         messages.put(AlertID.PLAYER_IDLE, "You are no longer pickpocketing!");
         messages.put(AlertID.NO_INVENTORY_SPACE, "There is no space for your loot!");
 		messages.put(AlertID.GLOVES_BREAK, "Your gloves of silence are about to break!");
-        messages.put(AlertID.EAT_FOOD, "Current health at or below the set threshold! Eat some food to continue pickpocketing.");
+        messages.put(AlertID.PICKPOCKET_PREVENTED, "Pickpocket prevented. Eat some food to continue.");
     }
 
     /**

--- a/src/main/java/com/pickpockethelper/AlertManager.java
+++ b/src/main/java/com/pickpockethelper/AlertManager.java
@@ -38,6 +38,7 @@ public class AlertManager {
         messages.put(AlertID.PLAYER_IDLE, "You are no longer pickpocketing!");
         messages.put(AlertID.NO_INVENTORY_SPACE, "There is no space for your loot!");
 		messages.put(AlertID.GLOVES_BREAK, "Your gloves of silence are about to break!");
+        messages.put(AlertID.EAT_FOOD, "Current health at or below the set threshold! Eat some food to continue pickpocketing.");
     }
 
     /**

--- a/src/main/java/com/pickpockethelper/PickpocketHelperConfig.java
+++ b/src/main/java/com/pickpockethelper/PickpocketHelperConfig.java
@@ -138,18 +138,6 @@ public interface PickpocketHelperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "preventAtOrBelowThreshold",
-			name = "Prevent Pickpocket on Alert",
-			description = "Prevent pickpocket when health is at or below the specified HP Threshold.",
-			position = 0,
-			section = soundSection
-	)
-	default boolean preventAtOrBelowThreshold()
-	{
-		return false;
-	}
-
-	@ConfigItem(
 		keyName = "hpThreshold",
 		name = "HP Threshold",
 		description = "The hitpoint threshold for being notified. A value of 0 will disable the notification.",
@@ -284,6 +272,18 @@ public interface PickpocketHelperConfig extends Config
 		section = utilitySection
 	)
 	default boolean enableLeftClickPickpocket()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "preventAtOrBelowThreshold",
+			name = "Prevent Pickpocket on Alert",
+			description = "Prevent pickpocket when health is at or below the specified HP Threshold.",
+			position = 3,
+			section = utilitySection
+	)
+	default boolean preventAtOrBelowThreshold()
 	{
 		return false;
 	}

--- a/src/main/java/com/pickpockethelper/PickpocketHelperConfig.java
+++ b/src/main/java/com/pickpockethelper/PickpocketHelperConfig.java
@@ -138,6 +138,18 @@ public interface PickpocketHelperConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "preventAtOrBelowThreshold",
+			name = "Prevent Pickpocket on Alert",
+			description = "Prevent pickpocket when health is at or below the specified HP Threshold.",
+			position = 0,
+			section = soundSection
+	)
+	default boolean preventAtOrBelowThreshold()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "hpThreshold",
 		name = "HP Threshold",
 		description = "The hitpoint threshold for being notified. A value of 0 will disable the notification.",

--- a/src/main/java/com/pickpockethelper/PickpocketHelperPlugin.java
+++ b/src/main/java/com/pickpockethelper/PickpocketHelperPlugin.java
@@ -249,6 +249,12 @@ public class PickpocketHelperPlugin extends Plugin {
 			return;
 		}
 
+        int currentHealth = this.client.getBoostedSkillLevel(Skill.HITPOINTS);
+        if(currentHealth <= config.getHitpointsThreshold() && config.preventAtOrBelowThreshold()) {
+            menuOptionClicked.consume();
+            this.client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Current health at or below the set threshold! Eat some food.", null);
+        }
+
 		session.getTarget().setNpc(menuOptionClicked.getMenuEntry().getNpc());
 		session.updateLastPickpocketAttempt();
 		session.getSplasher().updateIsAttacking();

--- a/src/main/java/com/pickpockethelper/PickpocketHelperPlugin.java
+++ b/src/main/java/com/pickpockethelper/PickpocketHelperPlugin.java
@@ -252,7 +252,7 @@ public class PickpocketHelperPlugin extends Plugin {
         int currentHealth = this.client.getBoostedSkillLevel(Skill.HITPOINTS);
         if (currentHealth <= config.getHitpointsThreshold() && config.preventAtOrBelowThreshold()) {
             menuOptionClicked.consume();
-            alertManager.sendAlert(AlertID.EAT_FOOD, true);
+            alertManager.sendAlert(AlertID.PICKPOCKET_PREVENTED, true);
         }
 
 		session.getTarget().setNpc(menuOptionClicked.getMenuEntry().getNpc());

--- a/src/main/java/com/pickpockethelper/PickpocketHelperPlugin.java
+++ b/src/main/java/com/pickpockethelper/PickpocketHelperPlugin.java
@@ -250,9 +250,9 @@ public class PickpocketHelperPlugin extends Plugin {
 		}
 
         int currentHealth = this.client.getBoostedSkillLevel(Skill.HITPOINTS);
-        if(currentHealth <= config.getHitpointsThreshold() && config.preventAtOrBelowThreshold()) {
+        if (currentHealth <= config.getHitpointsThreshold() && config.preventAtOrBelowThreshold()) {
             menuOptionClicked.consume();
-            this.client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Current health at or below the set threshold! Eat some food.", null);
+            alertManager.sendAlert(AlertID.EAT_FOOD, true);
         }
 
 		session.getTarget().setNpc(menuOptionClicked.getMenuEntry().getNpc());

--- a/src/main/java/com/pickpockethelper/utility/AlertID.java
+++ b/src/main/java/com/pickpockethelper/utility/AlertID.java
@@ -11,5 +11,5 @@ public class AlertID {
     public final static int TARGET_DESPAWN = 7;
 	public final static int GLOVES_BREAK = 8;
 
-    public final static int EAT_FOOD = 9;
+    public final static int PICKPOCKET_PREVENTED = 9;
 }

--- a/src/main/java/com/pickpockethelper/utility/AlertID.java
+++ b/src/main/java/com/pickpockethelper/utility/AlertID.java
@@ -10,4 +10,6 @@ public class AlertID {
     public final static int SPLASHER_IDLE = 6;
     public final static int TARGET_DESPAWN = 7;
 	public final static int GLOVES_BREAK = 8;
+
+    public final static int EAT_FOOD = 9;
 }


### PR DESCRIPTION
Adds utility toggle that can be toggled on to disable pickpocket actions from resolving when player is at or below the specified HP Threshold. If a pickpocket is prevented in this way, a game message is displayed prompting the user to eat food. This toggle can be found under the utility section of the settings and is useful to prevent deaths while pickpocketing such as for hardcore ironmen.